### PR TITLE
Make VerifyJWT extract JWT claims

### DIFF
--- a/pkg/authentication/auth0.go
+++ b/pkg/authentication/auth0.go
@@ -20,18 +20,18 @@ type auth0 struct {
 }
 
 // VerifyJWT verifies that the given token is a valid JWT and was correctly signed by Auth0.
-func (auth *auth0) VerifyJWT(ctx context.Context, token string) error {
+func (auth *auth0) VerifyJWT(ctx context.Context, token string) (jwt.Claims, error) {
 	if err := validateJWT(token); err != nil {
-		return err
+		return nil, err
 	}
 	parsedToken, err := jwt.Parse(token, auth.keyFunc)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if !parsedToken.Valid {
-		return ErrTokenInvalid
+		return nil, ErrTokenInvalid
 	}
-	return nil
+	return parsedToken.Claims, nil
 }
 
 func (auth *auth0) keyFunc(token *jwt.Token) (interface{}, error) {

--- a/pkg/authentication/authentication.go
+++ b/pkg/authentication/authentication.go
@@ -8,7 +8,7 @@ import (
 )
 
 // TokenAuthentication is the signature that a function should fulfill in order to verify an access token.
-type TokenAuthentication func(context.Context, string) error
+type TokenAuthentication func(context.Context, string) (jwt.Claims, error)
 
 // Authentication contains a set of methods to authenticate users through different authentication providers such as
 // Auth0, Google Identity Platform, and such.

--- a/pkg/authentication/authentication.go
+++ b/pkg/authentication/authentication.go
@@ -3,6 +3,7 @@ package authentication
 import (
 	"context"
 	"fmt"
+	"github.com/golang-jwt/jwt/v5"
 	"strings"
 )
 
@@ -13,7 +14,7 @@ type TokenAuthentication func(context.Context, string) error
 // Auth0, Google Identity Platform, and such.
 type Authentication interface {
 	// VerifyJWT verifies that the given token is a valid JWT and was correctly signed by the Authentication provider.
-	VerifyJWT(ctx context.Context, token string) error
+	VerifyJWT(ctx context.Context, token string) (jwt.Claims, error)
 }
 
 // validateJWT validates that the given token is a valid JWT.

--- a/pkg/authentication/authentication_test.go
+++ b/pkg/authentication/authentication_test.go
@@ -1,0 +1,25 @@
+package authentication
+
+import (
+	"context"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func AssertTokenValidation(t *testing.T, authentication Authentication) {
+	ctx := context.TODO()
+	_, err := authentication.VerifyJWT(ctx, "")
+	assert.Error(t, err)
+
+	_, err = authentication.VerifyJWT(ctx, "1234")
+	assert.Error(t, err)
+
+	_, err = authentication.VerifyJWT(ctx, ".eyJpc3MiOiJodHRwczovL215LWRvbWFpbi5hdXRoMC5jb20vIiwic3ViIjoiYXV0aDB8MTIzNDU2IiwiYXVkIjpbImh0dHBzOi8vZXhhbXBsZS5jb20vaGVhbHRoLWFwaSIsImh0dHBzOi8vbXktZG9tYWluLmF1dGgwLmNvbS91c2VyaW5mbyJdLCJhenAiOiJteV9jbGllbnRfaWQiLCJleHAiOjEzMTEyODE5NzAsImlhdCI6MTMxMTI4MDk3MCwic2NvcGUiOiJvcGVuaWQgcHJvZmlsZSByZWFkOnBhdGllbnRzIHJlYWQ6YWRtaW4ifQ.9QkZxtBr6Z5uuZEYNFfjRNBlGhY5hGzBUG71DgF-IJY")
+	assert.Error(t, err)
+
+	_, err = authentication.VerifyJWT(ctx, "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..9QkZxtBr6Z5uuZEYNFfjRNBlGhY5hGzBUG71DgF-IJY")
+	assert.Error(t, err)
+
+	_, err = authentication.VerifyJWT(ctx, "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL215LWRvbWFpbi5hdXRoMC5jb20vIiwic3ViIjoiYXV0aDB8MTIzNDU2IiwiYXVkIjpbImh0dHBzOi8vZXhhbXBsZS5jb20vaGVhbHRoLWFwaSIsImh0dHBzOi8vbXktZG9tYWluLmF1dGgwLmNvbS91c2VyaW5mbyJdLCJhenAiOiJteV9jbGllbnRfaWQiLCJleHAiOjEzMTEyODE5NzAsImlhdCI6MTMxMTI4MDk3MCwic2NvcGUiOiJvcGVuaWQgcHJvZmlsZSByZWFkOnBhdGllbnRzIHJlYWQ6YWRtaW4ifQ.")
+	assert.Error(t, err)
+}

--- a/pkg/authentication/firebase.go
+++ b/pkg/authentication/firebase.go
@@ -133,3 +133,19 @@ func (ft firebaseClaims) GetAudience() (jwt.ClaimStrings, error) {
 func NewFirebaseClaims(token auth.Token) jwt.Claims {
 	return firebaseClaims(token)
 }
+
+// NewFirebaseTestToken creates a new auth.Token for testing purposes.
+func NewFirebaseTestToken() auth.Token {
+	return auth.Token{
+		AuthTime: 3600,
+		Issuer:   "firebase",
+		Audience: "gazebosim.org",
+		Expires:  time.Now().Add(1 * time.Hour).Unix(),
+		IssuedAt: time.Now().Unix(),
+		Subject:  "gazebo-web",
+		UID:      "1234",
+		Firebase: auth.FirebaseInfo{
+			SignInProvider: "google",
+		},
+	}
+}

--- a/pkg/authentication/firebase.go
+++ b/pkg/authentication/firebase.go
@@ -34,7 +34,7 @@ func (auth *firebaseAuthentication) VerifyJWT(ctx context.Context, token string)
 		return nil, err
 	}
 
-	return newFirebaseClaims(*verifiedToken), nil
+	return NewFirebaseClaims(*verifiedToken), nil
 }
 
 // NewFirebaseWithTokenVerifier initializes a new Authentication implementation using Firebase.
@@ -129,7 +129,7 @@ func (ft firebaseClaims) GetAudience() (jwt.ClaimStrings, error) {
 	return []string{ft.Audience}, nil
 }
 
-// newFirebaseClaims initializes a new set of claims from the given firebase token.
-func newFirebaseClaims(token auth.Token) jwt.Claims {
+// NewFirebaseClaims initializes a new set of claims from the given firebase token.
+func NewFirebaseClaims(token auth.Token) jwt.Claims {
 	return firebaseClaims(token)
 }

--- a/pkg/authentication/firebase_test.go
+++ b/pkg/authentication/firebase_test.go
@@ -21,10 +21,10 @@ func TestFirebaseTestSuite(t *testing.T) {
 }
 
 func (suite *firebaseTestSuite) SetupSuite() {
-	suite.token = newFirebaseToken()
+	suite.token = NewFirebaseToken()
 }
 
-func newFirebaseToken() auth.Token {
+func NewFirebaseToken() auth.Token {
 	return auth.Token{
 		AuthTime: 3600,
 		Issuer:   "firebase",
@@ -92,9 +92,9 @@ func verifierWithError(err error) FirebaseTokenVerifier {
 }
 
 func TestNewFirebaseClaims(t *testing.T) {
-	token := newFirebaseToken()
+	token := NewFirebaseToken()
 
-	claims := newFirebaseClaims(token)
+	claims := NewFirebaseClaims(token)
 	assert.NotNil(t, claims)
 
 	date, err := claims.GetExpirationTime()

--- a/pkg/authentication/firebase_test.go
+++ b/pkg/authentication/firebase_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"firebase.google.com/go/v4/auth"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"testing"
 	"time"
@@ -20,7 +22,11 @@ func TestFirebaseTestSuite(t *testing.T) {
 }
 
 func (suite *firebaseTestSuite) SetupSuite() {
-	suite.token = auth.Token{
+	suite.token = newFirebaseToken()
+}
+
+func newFirebaseToken() auth.Token {
+	return auth.Token{
 		AuthTime: 3600,
 		Issuer:   "firebase",
 		Audience: "gazebosim.org",
@@ -35,27 +41,18 @@ func (suite *firebaseTestSuite) SetupSuite() {
 }
 
 func (suite *firebaseTestSuite) TestVerifyCredentials_InvalidToken() {
-	ctx := context.Background()
-
-	suite.Assert().Error(suite.authentication.VerifyJWT(ctx, ""))
-
-	suite.Assert().Error(suite.authentication.VerifyJWT(ctx, "1234"))
-
-	suite.Assert().Error(suite.authentication.VerifyJWT(ctx, ".eyJpc3MiOiJodHRwczovL215LWRvbWFpbi5hdXRoMC5jb20vIiwic3ViIjoiYXV0aDB8MTIzNDU2IiwiYXVkIjpbImh0dHBzOi8vZXhhbXBsZS5jb20vaGVhbHRoLWFwaSIsImh0dHBzOi8vbXktZG9tYWluLmF1dGgwLmNvbS91c2VyaW5mbyJdLCJhenAiOiJteV9jbGllbnRfaWQiLCJleHAiOjEzMTEyODE5NzAsImlhdCI6MTMxMTI4MDk3MCwic2NvcGUiOiJvcGVuaWQgcHJvZmlsZSByZWFkOnBhdGllbnRzIHJlYWQ6YWRtaW4ifQ.9QkZxtBr6Z5uuZEYNFfjRNBlGhY5hGzBUG71DgF-IJY"))
-
-	suite.Assert().Error(suite.authentication.VerifyJWT(ctx, "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..9QkZxtBr6Z5uuZEYNFfjRNBlGhY5hGzBUG71DgF-IJY"))
-
-	suite.Assert().Error(suite.authentication.VerifyJWT(ctx, "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL215LWRvbWFpbi5hdXRoMC5jb20vIiwic3ViIjoiYXV0aDB8MTIzNDU2IiwiYXVkIjpbImh0dHBzOi8vZXhhbXBsZS5jb20vaGVhbHRoLWFwaSIsImh0dHBzOi8vbXktZG9tYWluLmF1dGgwLmNvbS91c2VyaW5mbyJdLCJhenAiOiJteV9jbGllbnRfaWQiLCJleHAiOjEzMTEyODE5NzAsImlhdCI6MTMxMTI4MDk3MCwic2NvcGUiOiJvcGVuaWQgcHJvZmlsZSByZWFkOnBhdGllbnRzIHJlYWQ6YWRtaW4ifQ."))
+	AssertTokenValidation(suite.T(), suite.authentication)
 }
 
 func (suite *firebaseTestSuite) TestVerifyCredentials_FirebaseReturnsError() {
 	ctx := context.Background()
 
-	err := errors.New("firebase failed to verify Token")
+	expectedError := errors.New("firebase failed to verify Token")
 
-	suite.authentication = NewFirebaseWithTokenVerifier(verifierWithError(err))
+	suite.authentication = NewFirebaseWithTokenVerifier(verifierWithError(expectedError))
 
-	suite.Assert().ErrorIs(suite.authentication.VerifyJWT(ctx, "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJmaXJlYmFzZSIsImF1ZCI6ImdhemVib3NpbS5vcmciLCJzdWIiOiJnYXplYm8td2ViIiwidWlkIjoiMTIzNCIsImlhdCI6MTUxNjIzOTAyMn0.JTr0bynKo2txHf5uE7qinJ063Nrbjb8o_bmv_EttP-eMpN-ommwVu5zqO4WC3jn5jOThQge0i17CZhWaoalcJQ"), err)
+	_, err := suite.authentication.VerifyJWT(ctx, "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJmaXJlYmFzZSIsImF1ZCI6ImdhemVib3NpbS5vcmciLCJzdWIiOiJnYXplYm8td2ViIiwidWlkIjoiMTIzNCIsImlhdCI6MTUxNjIzOTAyMn0.JTr0bynKo2txHf5uE7qinJ063Nrbjb8o_bmv_EttP-eMpN-ommwVu5zqO4WC3jn5jOThQge0i17CZhWaoalcJQ")
+	suite.Assert().ErrorIs(err, expectedError)
 }
 
 func (suite *firebaseTestSuite) TestVerifyCredentials_Success() {
@@ -63,7 +60,13 @@ func (suite *firebaseTestSuite) TestVerifyCredentials_Success() {
 
 	suite.authentication = NewFirebaseWithTokenVerifier(verifierWithToken(&suite.token))
 
-	suite.Assert().NoError(suite.authentication.VerifyJWT(ctx, "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJmaXJlYmFzZSIsImF1ZCI6ImdhemVib3NpbS5vcmciLCJzdWIiOiJnYXplYm8td2ViIiwidWlkIjoiMTIzNCIsImlhdCI6MTUxNjIzOTAyMn0.JTr0bynKo2txHf5uE7qinJ063Nrbjb8o_bmv_EttP-eMpN-ommwVu5zqO4WC3jn5jOThQge0i17CZhWaoalcJQ"))
+	claims, err := suite.authentication.VerifyJWT(ctx, "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJmaXJlYmFzZSIsImF1ZCI6ImdhemVib3NpbS5vcmciLCJzdWIiOiJnYXplYm8td2ViIiwidWlkIjoiMTIzNCIsImlhdCI6MTUxNjIzOTAyMn0.JTr0bynKo2txHf5uE7qinJ063Nrbjb8o_bmv_EttP-eMpN-ommwVu5zqO4WC3jn5jOThQge0i17CZhWaoalcJQ")
+	suite.Assert().NoError(err)
+
+	sub, err := claims.GetSubject()
+	suite.Assert().NoError(err)
+	suite.Assert().NotEmpty(sub)
+	suite.Assert().Equal("gazebo-web", sub)
 }
 
 type testVerifier struct {
@@ -87,4 +90,40 @@ func verifierWithToken(token *auth.Token) FirebaseTokenVerifier {
 
 func verifierWithError(err error) FirebaseTokenVerifier {
 	return testVerifier{Error: err}
+}
+
+func TestNewFirebaseClaims(t *testing.T) {
+	token := newFirebaseToken()
+	var claims jwt.Claims
+	claims = newFirebaseClaims(token)
+	assert.NotNil(t, claims)
+
+	date, err := claims.GetExpirationTime()
+	assert.NoError(t, err)
+	assert.NotNil(t, date)
+	assert.True(t, time.Unix(token.Expires, 0).Equal(date.Time))
+
+	date, err = claims.GetIssuedAt()
+	assert.NoError(t, err)
+	assert.NotNil(t, date)
+	assert.True(t, time.Unix(token.IssuedAt, 0).Equal(date.Time))
+
+	_, err = claims.GetNotBefore()
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "not implemented")
+
+	iss, err := claims.GetIssuer()
+	assert.NoError(t, err)
+	assert.NotEmpty(t, iss)
+	assert.Equal(t, token.Issuer, iss)
+
+	sub, err := claims.GetSubject()
+	assert.NoError(t, err)
+	assert.NotEmpty(t, sub)
+	assert.Equal(t, token.Subject, sub)
+
+	aud, err := claims.GetAudience()
+	assert.NoError(t, err)
+	assert.NotEmpty(t, aud)
+	assert.EqualValues(t, []string{token.Audience}, aud)
 }

--- a/pkg/authentication/firebase_test.go
+++ b/pkg/authentication/firebase_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"firebase.google.com/go/v4/auth"
-	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"testing"
@@ -94,8 +93,8 @@ func verifierWithError(err error) FirebaseTokenVerifier {
 
 func TestNewFirebaseClaims(t *testing.T) {
 	token := newFirebaseToken()
-	var claims jwt.Claims
-	claims = newFirebaseClaims(token)
+
+	claims := newFirebaseClaims(token)
 	assert.NotNil(t, claims)
 
 	date, err := claims.GetExpirationTime()

--- a/pkg/authentication/firebase_test.go
+++ b/pkg/authentication/firebase_test.go
@@ -21,22 +21,7 @@ func TestFirebaseTestSuite(t *testing.T) {
 }
 
 func (suite *firebaseTestSuite) SetupSuite() {
-	suite.token = NewFirebaseToken()
-}
-
-func NewFirebaseToken() auth.Token {
-	return auth.Token{
-		AuthTime: 3600,
-		Issuer:   "firebase",
-		Audience: "gazebosim.org",
-		Expires:  time.Now().Add(1 * time.Hour).Unix(),
-		IssuedAt: time.Now().Unix(),
-		Subject:  "gazebo-web",
-		UID:      "1234",
-		Firebase: auth.FirebaseInfo{
-			SignInProvider: "google",
-		},
-	}
+	suite.token = NewFirebaseTestToken()
 }
 
 func (suite *firebaseTestSuite) TestVerifyCredentials_InvalidToken() {
@@ -92,7 +77,7 @@ func verifierWithError(err error) FirebaseTokenVerifier {
 }
 
 func TestNewFirebaseClaims(t *testing.T) {
-	token := NewFirebaseToken()
+	token := NewFirebaseTestToken()
 
 	claims := NewFirebaseClaims(token)
 	assert.NotNil(t, claims)


### PR DESCRIPTION
# Context
Applications using this library would like to access the claims provided from incoming JWTs.

# Change
This PR changes the `Authentication` interface to make the `VerifyJWT` method extract the JWT claims.

# Future work
Set context value on the interceptor defined in `gz-go`.