### PR TITLE
Add support for getting email values from firebase claims

### DIFF
--- a/pkg/authentication/authentication.go
+++ b/pkg/authentication/authentication.go
@@ -16,6 +16,13 @@ type Authentication interface {
 	VerifyJWT(ctx context.Context, token string) error
 }
 
+// EmailClaimer allows to get an email from a custom JWT claim.
+// NOTE: Not all authentication providers embed an email in their JWT.
+type EmailClaimer interface {
+	// GetEmail returns an email from a custom JWT claim.
+	GetEmail() (string, error)
+}
+
 // validateJWT validates that the given token is a valid JWT.
 func validateJWT(token string) error {
 	if len(token) == 0 {

--- a/pkg/authentication/authentication.go
+++ b/pkg/authentication/authentication.go
@@ -20,7 +20,7 @@ type Authentication interface {
 // EmailClaimer allows to get an email from a custom JWT claim.
 // NOTE: Not all authentication providers embed an email in their JWT.
 type EmailClaimer interface {
-	// GetEmail returns an email from a custom JWT claim.
+	// GetEmail returns the user's email from a custom JWT claim.
 	GetEmail() (string, error)
 }
 

--- a/pkg/authentication/firebase.go
+++ b/pkg/authentication/firebase.go
@@ -118,7 +118,7 @@ func (ft firebaseClaims) GetEmail() (string, error) {
 func (ft firebaseClaims) getCustomClaim(key string) (any, error) {
 	v, ok := ft.Claims[key]
 	if !ok {
-		return nil, fmt.Errorf("failed to get %s value", key)
+		return nil, fmt.Errorf("failed to get %s value: not found", key)
 	}
 	return v, nil
 }

--- a/pkg/authentication/firebase.go
+++ b/pkg/authentication/firebase.go
@@ -87,6 +87,7 @@ func NewFirebase(app *firebase.App) (FirebaseTokenVerifier, error) {
 }
 
 var _ jwt.Claims = (*firebaseClaims)(nil)
+var _ EmailClaimer = (*firebaseClaims)(nil)
 
 // firebaseClaims implements the jwt.Claims interface on auth.Token.
 type firebaseClaims auth.Token


### PR DESCRIPTION
This PR allows us to get email values from claims, and adds support for extracting the email from firebase claims.